### PR TITLE
feat: prev-less planning + built-in verify + auto transport

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,8 +8,8 @@ Hotweights delivers fast, versioned weight updates for LLM serving and training.
 
 ## Flow
 
-1. Publisher posts a new checkpoint and builds manifests (prev/next).
-2. Planner computes delta and packs items into buckets (size‑aware).
+1. Publisher posts a new checkpoint and builds the next manifest. The current (prev) manifest is tracked by the coordinator.
+2. Planner computes delta (prev vs next) and packs items into buckets (size‑aware). Plan includes `plan_version` and a verification report.
 3. Transport replicates: root assembles buckets and broadcasts/IPC shares to consumers.
 4. Workers/adapters load staged shards (CPU→GPU or IPC→device) into shadow storage and commit.
 5. Late joiners fetch missing buckets and join at the next commit.
@@ -51,4 +51,3 @@ Hotweights delivers fast, versioned weight updates for LLM serving and training.
 ## Optional Dependencies
 
 - CUDA/Torch for IPC path; Bodo for planning acceleration; UCX‑Py and mpi4py for fallbacks; pyzmq for control plane; Redis for HA; CuPy + KvikIO for GDS.
-

--- a/docs/PRESETS.md
+++ b/docs/PRESETS.md
@@ -64,5 +64,4 @@ export HOTWEIGHTS_OPT_ATTENUATION=0.5
 Notes
 
 - The adaptive window publishes current vs recommended window via metrics; use the provided Grafana dashboard to monitor inflight buckets/bytes, congestion risk, and path utilization.
-- For multi-node clusters, pair CUDA-IPC intra-node with UCX or MPI inter-node as needed.
-
+- For multi-node clusters, pair CUDA-IPC intra-node with the auto-selected CPU transport (MPI > UCX) for inter-node traffic.

--- a/docs/TP_GROUPS.md
+++ b/docs/TP_GROUPS.md
@@ -24,7 +24,7 @@ Example (JSON file):
     "1": [4, 5, 6, 7]
   }
   
-  $ HOTWEIGHTS_TP_GROUPS=groups.json hotweights plan --prev prev.json --next next.json --bucket-mb 512
+  $ HOTWEIGHTS_TP_GROUPS=groups.json hotweights plan --next next.json --bucket-mb 512 --coord-endpoint tcp://127.0.0.1:5555
 
 Validation Rules
 
@@ -36,4 +36,3 @@ Notes
 
 - If `partitioning.tp_group` (or `group`/`group_id`) is missing on tensors, the mapping cannot be applied for those items.
 - `consumer_ranks` affects broadcast and scatter; buckets are only transmitted to the listed ranks in MPI/UCX/CUDA-IPC paths.
-

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -48,8 +48,7 @@ HA Control Plane
 - HOTWEIGHTS_COORD_BACKEND=redis to use Redis; HOTWEIGHTS_REDIS_URL
 - HOTWEIGHTS_HANDLE_TTL seconds; handle acks shorten TTL.
 
-UCX/MPI Fallbacks
+CPU Transport Fallbacks (auto-selected)
 
 - UCX: HOTWEIGHTS_UCX_CHUNK_MB, HOTWEIGHTS_UCX_CONCURRENCY, HOTWEIGHTS_UCX_INFLIGHT_LIMIT_MB, HOTWEIGHTS_UCX_RETRIES, HOTWEIGHTS_UCX_RETRY_DELAY_MS
-- MPI: --window, --mpi-chunk-mb CLI flags
-
+- MPI: --window, --mpi-chunk-mb CLI flags (optional overrides)

--- a/docs/WALKTHROUGHS.md
+++ b/docs/WALKTHROUGHS.md
@@ -26,7 +26,7 @@ dd if=/dev/zero of=demo_ckpt_b/b.bin bs=1m count=8 >/dev/null 2>&1
 # Publish, plan, and verify
 hotweights publish --checkpoint demo_ckpt_a --version v0 --output m_prev.json
 hotweights publish --checkpoint demo_ckpt_b --version v1 --output m_next.json
-hotweights plan --prev m_prev.json --next m_next.json --bucket-mb 64 --output plan.json
+hotweights plan --next m_next.json --bucket-mb 64 --strict --output plan.json
 hotweights verify-plan --plan plan.json --require-consumers || true
 
 # Replicate (CUDA-IPC preferred); metrics on :9097
@@ -62,7 +62,7 @@ echo "world" > demo_ckpt_b/b.bin
 
 hotweights publish --checkpoint demo_ckpt_a --version v0 --output m_prev.json
 hotweights publish --checkpoint demo_ckpt_b --version v1 --output m_next.json
-hotweights plan --prev m_prev.json --next m_next.json --bucket-mb 8 --output plan.json
+hotweights plan --next m_next.json --bucket-mb 8 --coord-endpoint tcp://127.0.0.1:5555 --strict --output plan.json
 hotweights verify-plan --plan plan.json --world-size 1 || true
 
 # Submit plan and begin
@@ -85,4 +85,3 @@ Notes
 
 - For multi-node deployments, pair CUDA-IPC intra-node with UCX or MPI inter-node as needed; use TP group mappings (docs/TP_GROUPS.md) to scope consumer_ranks.
 - The HA coordinator can be run without Redis; Redis adds durability and TTL cleanup but is optional.
-

--- a/hotweights/adapters/base.py
+++ b/hotweights/adapters/base.py
@@ -1,0 +1,22 @@
+"""Adapter protocol for server-plane integrations (vLLM, trainers)."""
+from __future__ import annotations
+
+from typing import Protocol, Dict, List
+
+
+class HotweightsAdapter(Protocol):
+    def begin_update(self, version: str, manifest: Dict) -> None:
+        ...
+
+    def request_buffer(self, tensor: str, shard_rank: int, nbytes: int):  # noqa: ANN201
+        ...
+
+    def finalize_shard(self, tensor: str, shard_rank: int, hash_: str) -> None:
+        ...
+
+    def precommit(self) -> None:
+        ...
+
+    def commit(self, version: str) -> None:
+        ...
+

--- a/hotweights/core/errors.py
+++ b/hotweights/core/errors.py
@@ -1,0 +1,19 @@
+"""Common exceptions for hotweights library."""
+from __future__ import annotations
+
+
+class HotweightsError(Exception):
+    pass
+
+
+class ValidationError(HotweightsError):
+    pass
+
+
+class TransportError(HotweightsError):
+    pass
+
+
+class CoordinatorError(HotweightsError):
+    pass
+

--- a/hotweights/core/schemas.py
+++ b/hotweights/core/schemas.py
@@ -1,0 +1,62 @@
+"""Shared schema types for manifests, plans, and items.
+
+Define stable TypedDicts for interchange between components.
+"""
+from __future__ import annotations
+
+from typing import List, Dict, Optional, TypedDict, Literal
+
+
+# Versioning for plan schema produced by create_plan
+PLAN_SCHEMA_VERSION: str = "1"
+
+
+class Shard(TypedDict):
+    rank: int
+    bytes: int
+    hash: str
+    uri: str
+
+
+class TensorEntry(TypedDict, total=False):
+    name: str
+    dtype: Optional[str]
+    shape: Optional[List[int]]
+    partitioning: Dict[str, int | str]
+    quant: Dict[str, object]
+    shards: List[Shard]
+
+
+class Manifest(TypedDict):
+    model_id: str
+    version: str
+    tensors: List[TensorEntry]
+
+
+class PlanItem(TypedDict, total=False):
+    tensor: str
+    shard_rank: int
+    nbytes: int
+    hash: str
+    uri: str
+    dtype: Optional[str]
+    shape: Optional[List[int]]
+    key: str
+    offset: int
+
+
+class PlanBucket(TypedDict, total=False):
+    bucket_id: int
+    size: int
+    items: List[PlanItem]
+    consumer_ranks: List[int]
+
+
+class Plan(TypedDict, total=False):
+    plan_version: str
+    version: str  # next version
+    bucket_bytes: int
+    total_bytes: int
+    buckets: List[PlanBucket]
+    verification: Dict[str, object]
+

--- a/hotweights/planner_bodo.py
+++ b/hotweights/planner_bodo.py
@@ -93,3 +93,23 @@ else:
         print("[hotweights] Using pandas implementations (HOTWEIGHTS_FORCE_PANDAS)")
     compute_delta = _compute_delta_pd
     pack_buckets = _pack_buckets_pd
+
+
+def warmup() -> None:
+    """Optional JIT warmup for planner functions.
+
+    Compiles the Bodo JIT versions (when available) using tiny DataFrames to
+    amortize first-call latency in long-lived processes.
+    """
+    try:
+        import pandas as _pd
+        prev = _pd.DataFrame([
+            {"tensor": "t", "shard_rank": 0, "nbytes": 1, "hash": "h0", "path": "t"}
+        ])
+        nxt = _pd.DataFrame([
+            {"tensor": "t", "shard_rank": 0, "nbytes": 1, "hash": "h1", "path": "t"}
+        ])
+        _ = compute_delta(prev, nxt)
+        _ = pack_buckets(nxt, bucket_bytes=8)
+    except Exception:
+        pass

--- a/hotweights/staging/base.py
+++ b/hotweights/staging/base.py
@@ -1,0 +1,22 @@
+"""Staging agent base interfaces."""
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class StagingAgent(Protocol):
+    def reserve(self, key: str, nbytes: int) -> memoryview:
+        ...
+
+    def write(self, key: str, off: int, buf: memoryview) -> None:
+        ...
+
+    def seal(self, key: str) -> str:
+        ...
+
+    def read(self, key: str) -> memoryview:
+        ...
+
+    def torch_tensor(self, key: str):  # optional
+        ...
+

--- a/hotweights/transport/base.py
+++ b/hotweights/transport/base.py
@@ -1,0 +1,23 @@
+"""Transport base interfaces."""
+from __future__ import annotations
+
+from typing import Protocol, Iterable, Callable, Tuple, List
+import numpy as np
+
+
+Bucket = Tuple[int, np.ndarray]
+
+
+class Transport(Protocol):
+    """Protocol for broadcast transports."""
+
+    def replicate(self, bucket_iter: Iterable[Bucket]) -> None:
+        ...
+
+    def replicate_stream(
+        self,
+        bucket_iter: Iterable[Tuple[int, np.ndarray] | Tuple[int, np.ndarray, List[int]]],
+        on_complete: Callable[[int, np.ndarray], None],
+    ) -> None:
+        ...
+

--- a/hotweights/transport/ucx_stream.py
+++ b/hotweights/transport/ucx_stream.py
@@ -23,6 +23,7 @@ except Exception:  # pragma: no cover
     ucp = None  # type: ignore
 
 from ..telemetry.prom import Counter, Gauge
+from .base import Transport
 from ..telemetry.logging import get_logger
 
 
@@ -30,7 +31,7 @@ Bucket = Tuple[int, np.ndarray]
 
 
 @dataclass
-class UCXReplicator:
+class UCXReplicator(Transport):
     window: int = 2
     chunk_bytes: int = 8 << 20  # 8 MiB chunks
     send_concurrency: int = 0  # 0 -> fanout to all peers per chunk

--- a/tests/test_cli_token.py
+++ b/tests/test_cli_token.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hotweights.cli import _cmd_replicate
+
+
+class _FakeClient:
+    def __init__(self, endpoint: str):  # noqa: ANN001
+        self.endpoint = endpoint
+        self.calls = []
+
+    def call(self, method: str, **kwargs):  # noqa: ANN003
+        self.calls.append((method, kwargs))
+        # return a dummy ok payload
+        return {"ok": True, "method": method, "args": kwargs}
+
+
+def test_cli_replicate_forwards_token(monkeypatch, tmp_path: Path):
+    # Create a minimal plan
+    plan = {"version": "v1", "bucket_bytes": 0, "total_bytes": 0, "buckets": []}
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps(plan))
+
+    # Monkeypatch Client to our fake
+    import hotweights.coordinator.zmq_client as zc
+
+    fake = _FakeClient("tcp://x")
+    monkeypatch.setattr(zc, "Client", lambda ep: fake)
+
+    # Prepare args namespace
+    class A:  # simple shim
+        plan = str(plan_path)
+        commit = False
+        device = "cpu"
+        coord_endpoint = "tcp://127.0.0.1:5555"
+        mpi = False
+        ucx = False
+        verify = False
+        window = 2
+        group = None
+        mpi_chunk_mb = 0
+        manifest_next = None
+
+    # Set token and call
+    monkeypatch.setenv("HOTWEIGHTS_COORD_TOKEN", "secret")
+    assert _cmd_replicate(A()) == 0
+    # Verify that token was forwarded in all calls
+    methods = [m for m, _ in fake.calls]
+    assert methods == ["submit_plan", "begin", "commit"]
+    for _, kw in fake.calls:
+        assert kw.get("token") == "secret"
+

--- a/tests/test_plan_from_current.py
+++ b/tests/test_plan_from_current.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hotweights.manifest import build_simple_manifest
+from hotweights.core.replicate import create_plan_from_current
+
+
+def _write_ckpt(root: Path, files: dict[str, bytes]) -> None:
+    for rel, data in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+
+
+def test_create_plan_from_current(tmp_path: Path) -> None:
+    ckpt_prev = tmp_path / "prev"
+    _write_ckpt(ckpt_prev, {"a.bin": b"a" * 4, "b.bin": b"b" * 2})
+    prev = build_simple_manifest("toy", "v0", ckpt_prev)
+
+    ckpt_next = tmp_path / "next"
+    _write_ckpt(ckpt_next, {"a.bin": b"a" * 4, "b.bin": b"B" * 3, "c.bin": b"c" * 2})
+    nxt = build_simple_manifest("toy", "v1", ckpt_next)
+
+    plan = create_plan_from_current(nxt, current_provider=lambda: prev, bucket_mb=1)
+
+    items = [i for b in plan["buckets"] for i in b["items"]]
+    names = sorted(set(i["tensor"] for i in items))
+    # a.bin unchanged; expect b.bin changed and c.bin new
+    assert names == ["b.bin", "c.bin"]
+

--- a/tests/test_transport_preference.py
+++ b/tests/test_transport_preference.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from hotweights.transport.transport_manager import TransportManager
+from hotweights.transport.ucx_stream import UCXReplicator
+from hotweights.transport.mpi_stream import MPIReplicator
+
+
+def test_transport_manager_preference_ucx(monkeypatch):
+    # Force discovery to believe both UCX (rdma) and MPI are available
+    monkeypatch.setattr(TransportManager, "_check_rdma_availability", lambda self: True)
+    monkeypatch.setattr(TransportManager, "_check_mpi_availability", lambda self: True)
+    # Build manager with a preference for UCX
+    tm = TransportManager(world_size=2, rank=0, auto_select=True, preferred_transport="ucx")
+    rep = tm.get_replicator()
+    assert isinstance(rep, UCXReplicator)
+
+
+def test_transport_manager_preference_mpi(monkeypatch):
+    monkeypatch.setattr(TransportManager, "_check_rdma_availability", lambda self: True)
+    monkeypatch.setattr(TransportManager, "_check_mpi_availability", lambda self: True)
+    tm = TransportManager(world_size=2, rank=0, auto_select=True, preferred_transport="mpi")
+    rep = tm.get_replicator()
+    assert isinstance(rep, MPIReplicator)
+

--- a/tests/test_verify_plan_core.py
+++ b/tests/test_verify_plan_core.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from hotweights.core.replicate import verify_plan
+
+
+def test_verify_plan_basic_missing_and_range():
+    plan = {
+        "buckets": [
+            {"bucket_id": 0, "items": [], "size": 0},  # no consumer_ranks
+            {"bucket_id": 1, "items": [], "size": 0, "consumer_ranks": [0, 1, 1]},  # dupes
+            {"bucket_id": 2, "items": [], "size": 0, "consumer_ranks": [3, 4]},  # out of range for ws=4
+        ]
+    }
+    report = verify_plan(plan, require_consumers=True, world_size=4)
+    assert report["buckets"] == 3
+    assert report["missing_consumer_ranks"] == 1
+    assert report["buckets_with_duplicates"] == 1
+    assert report["buckets_with_out_of_range"] == 1
+    assert len(report["problems"]) >= 2
+


### PR DESCRIPTION
This PR simplifies UX and hardens core flows.\n\nHighlights:\n- Plan UX: prev-less planning via coordinator current manifest; fallback to local cache; preserves explicit --prev path.\n- Verification: built-in plan verification in core; CLI verifies by default; --strict to fail, --no-verify to skip.\n- Transport: auto CPU transport selection (MPI > UCX > local); deprecate --mpi/--ucx flags (hidden, act as preferences).\n- Coordinator: add set/get_current_manifest RPCs, token-gated mutating RPCs, explicit state machine; status includes state/current_manifest.\n- Schemas/Protocols: add typed schemas for Plan/Manifest; Transport/Staging protocols.\n- Planner: optional JIT warmup; still Bodo-accelerated.\n- Docs: updated README (Quick start, Security, Developer Guide), ARCHITECTURE, DEPLOYMENT, WALKTHROUGHS, TP_GROUPS, PRESETS, TUNING.\n- Tests: new tests for verify_plan, plan_from_current, transport preference, and CLI token forwarding.\n\nNotes:\n- All tests pass locally: 16 passed, 7 warnings.\n- Flags --mpi/--ucx are now hidden but honored as preferences.\n- Coordinator token is forwarded via HOTWEIGHTS_COORD_TOKEN env.\n\nFollow-ups:\n- Further metrics registry unification; optional planner warmups in daemons; additional integration tests.
