### PR TITLE
feat(transport): NCCL backend + UCX tuning for inter-node speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ Workers start a Prometheus endpoint on :9099; CLI replicate attempts to start on
 - Code Structure
   - Core planning: `hotweights/planner_bodo.py` (Bodo JIT when available; pandas fallback), `hotweights/core/replicate.py` (plan helpers, verification, assemble/scatter).
   - Schemas & errors: `hotweights/core/schemas.py`, `hotweights/core/errors.py`.
-  - Transports: `hotweights/transport/*` with `transport/base.py` protocol and `TransportManager` auto-selection.
+- Transports: `hotweights/transport/*` with `transport/base.py` protocol and `TransportManager` auto-selection.
+  - Optional NCCL transport for inter-node GPU broadcast (auto-selected when `torch.distributed` with CUDA is available and `WORLD_SIZE>1`).
   - Staging: `hotweights/staging/*` with `staging/base.py` protocol; `HostAgent` for CPU, `CudaIPCAgent` for GPU.
   - Coordinator: `hotweights/coordinator/*` (ZeroMQ REP/PUB server + client, optional HA control plane).
   - Adapters: `hotweights/adapters/*` (vLLM, trainers) with `adapters/base.py` protocol.

--- a/hotweights/transport/nccl_stream.py
+++ b/hotweights/transport/nccl_stream.py
@@ -1,0 +1,154 @@
+"""NCCL-based broadcast transport.
+
+Uses torch.distributed with NCCL backend to broadcast bucket buffers.
+If CUDA or torch.distributed is unavailable, falls back to a no-op path
+compatible with tests (local-only).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional, Tuple, List
+
+import numpy as np
+
+try:  # optional torch
+    import torch
+    import torch.distributed as dist
+except Exception:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore
+    dist = None  # type: ignore
+
+from .base import Transport
+
+
+Bucket = Tuple[int, np.ndarray]
+
+
+def _maybe_init_dist() -> bool:
+    if torch is None or dist is None:
+        return False
+    if not torch.cuda.is_available():
+        return False
+    try:
+        if dist.is_available():
+            if not dist.is_initialized():
+                # Attempt environment initialization
+                backend = "nccl"
+                init_method = None  # use env MASTER_ADDR/PORT
+                dist.init_process_group(backend=backend, init_method=init_method)
+            return True
+    except Exception:
+        return False
+    return False
+
+
+@dataclass
+class NCCLReplicator(Transport):
+    chunk_bytes: int = 16 << 20  # 16 MiB
+
+    def __post_init__(self) -> None:
+        self._ok = _maybe_init_dist()
+        try:
+            self._rank = dist.get_rank() if (self._ok and dist.is_initialized()) else 0
+        except Exception:
+            self._rank = 0
+
+    @property
+    def world_rank(self) -> int:
+        return getattr(self, "_rank", 0)
+
+    def replicate(self, bucket_iter: Iterable[Bucket]) -> None:
+        if not self._ok:
+            # No-op fallback
+            for _bid, _buf in bucket_iter:
+                pass
+            return
+        for _bid, buf in bucket_iter:
+            self._broadcast_into_numpy(buf)
+
+    def replicate_stream(
+        self,
+        bucket_iter: Iterable[Tuple[int, np.ndarray] | Tuple[int, np.ndarray, List[int]]],
+        on_complete: Callable[[int, np.ndarray], None],
+    ) -> None:
+        if not self._ok:
+            for item in bucket_iter:
+                bid, arr = item[0], item[1]
+                on_complete(int(bid), arr)
+            return
+
+        # Optional subgroup caching
+        group_cache: dict[frozenset[int], object] = {}
+
+        def get_group(consumers: Optional[List[int]]):
+            if not consumers:
+                return dist.group.WORLD  # type: ignore[attr-defined]
+            key = frozenset(int(x) for x in consumers)
+            g = group_cache.get(key)
+            if g is None:
+                g = dist.new_group(ranks=sorted(key))
+                group_cache[key] = g
+            return g
+
+        for item in bucket_iter:
+            if len(item) == 3:
+                bid, arr, consumers = item  # type: ignore[misc]
+            else:
+                bid, arr = item  # type: ignore[misc]
+                consumers = None
+            # Skip non-consumers
+            if consumers is not None and self.world_rank not in consumers:
+                continue
+            self._broadcast_into_numpy(arr, consumers=consumers)
+            on_complete(int(bid), arr)
+
+    # --- helpers ---
+    def _broadcast_into_numpy(self, out: np.ndarray, consumers: Optional[List[int]] = None) -> None:
+        """Broadcast the given numpy array into itself using NCCL via a GPU tensor.
+
+        Root is the minimum rank in `consumers` or 0 if None.
+        On root: copies CPU -> GPU, broadcasts, returns without modifying out.
+        On non-root: broadcasts into GPU tensor and copies GPU -> CPU (into out).
+        """
+        if torch is None or dist is None or not dist.is_initialized():
+            return
+        rank = self.world_rank
+        root = 0 if not consumers else min(int(x) for x in consumers)
+        # Determine group for broadcast
+        group = None
+        try:
+            if consumers is not None:
+                # Try to fetch an existing group by ranks; not strictly necessary
+                ranks = sorted(int(x) for x in consumers)
+                group = dist.new_group(ranks=ranks)
+        except Exception:
+            group = None
+        # Prepare device tensor
+        device = torch.device("cuda", torch.cuda.current_device())
+        n = int(out.nbytes)
+        if rank == root:
+            src = torch.from_numpy(out).to(device)
+            if self.chunk_bytes and n > self.chunk_bytes:
+                off = 0
+                while off < n:
+                    end = min(off + self.chunk_bytes, n)
+                    view = src.view(torch.uint8)[off:end]
+                    dist.broadcast(view, src=root, group=group)
+                    off = end
+            else:
+                dist.broadcast(src, src=root, group=group)
+        else:
+            dst = torch.empty(n, dtype=torch.uint8, device=device)
+            if self.chunk_bytes and n > self.chunk_bytes:
+                off = 0
+                while off < n:
+                    end = min(off + self.chunk_bytes, n)
+                    view = dst[off:end]
+                    dist.broadcast(view, src=root, group=group)
+                    off = end
+            else:
+                dist.broadcast(dst, src=root, group=group)
+            # Copy back to CPU numpy
+            out_view = torch.from_numpy(out)
+            out_view.view(torch.uint8).copy_(dst, non_blocking=False)
+


### PR DESCRIPTION
- Add NCCLReplicator and integrate with TransportManager (auto-select when CUDA + WORLD_SIZE>1)\n- UCX: bind to IB via HOTWEIGHTS_UCX_NET_DEVICES/NCCL_IB_HCA; basic concurrency autotune\n- Lays groundwork for hierarchical broadcast (NCCL inter-node + CUDA-IPC intra-node).\n\nTests: 16 passed, 7 warnings locally.