### PR TITLE
fix: resolve transport/worker/vllm review regressions

### DIFF
--- a/hotweights/adapters/vllm_bind.py
+++ b/hotweights/adapters/vllm_bind.py
@@ -55,6 +55,9 @@ class HotweightsVLLMBinding:
         obj,
         name_map: dict[str, str] | Callable[[dict], dict[str, str]] | None,
         endpoint: str,
+        use_mpi: bool = False,
+        pinned: bool = True,
+        verify: bool = False,
         use_kv_migration: bool = True, # Use SOTA feature by default
         device: str = "cuda",
         poll_interval: float = 2.0,
@@ -63,6 +66,9 @@ class HotweightsVLLMBinding:
         self.module = _extract_module(obj)
         self.name_map = name_map
         self.endpoint = endpoint
+        self.use_mpi = use_mpi
+        self.pinned = pinned
+        self.verify = verify
         self.use_kv_migration = use_kv_migration
         self.device = device
         self.poll_interval = poll_interval
@@ -194,6 +200,9 @@ def bind_to_vllm(
     engine_or_runner,
     name_map: dict[str, str] | Callable[[dict], dict[str, str]] | None,
     endpoint: str = "tcp://127.0.0.1:5555",
+    use_mpi: bool = False,
+    pinned: bool = True,
+    verify: bool = False,
     use_kv_migration: bool = True,
     device: str = "cuda",
     poll_interval: float = 2.0,
@@ -203,6 +212,9 @@ def bind_to_vllm(
         engine_or_runner,
         name_map,
         endpoint=endpoint,
+        use_mpi=use_mpi,
+        pinned=pinned,
+        verify=verify,
         use_kv_migration=use_kv_migration,
         device=device,
         poll_interval=poll_interval,

--- a/hotweights/adapters/vllm_pause.py
+++ b/hotweights/adapters/vllm_pause.py
@@ -30,7 +30,7 @@ def find_engine(obj: Any) -> Any | None:
     return obj if hasattr(obj, "__dict__") else None
 
 
-def pause_requests(obj: Any, timeout_s: float = 5.0) -> None:
+def pause_requests(obj: Any, timeout_s: float = 5.0, drain: bool = True) -> None:
     eng = find_engine(obj) or obj
     # Try explicit pause methods
     for name in ("pause", "pause_requests", "block_new_requests"):
@@ -40,6 +40,8 @@ def pause_requests(obj: Any, timeout_s: float = 5.0) -> None:
                 break
             except Exception:
                 pass
+    if not drain:
+        return
     # Wait for in-flight to drain if we can observe
     deadline = time.time() + timeout_s
     for attr in ("num_active_requests", "active_requests", "running"):
@@ -70,4 +72,3 @@ def resume_requests(obj: Any) -> None:
                 break
             except Exception:
                 pass
-

--- a/hotweights/coordinator/zmq_server.py
+++ b/hotweights/coordinator/zmq_server.py
@@ -42,8 +42,11 @@ def _derive_pub_endpoint(endpoint: str) -> str:
     Only handles tcp://host:port. Falls back to tcp://127.0.0.1:5556.
     """
     try:
-        if endpoint.startswith("tcp://") and ":" in endpoint.rsplit(":", 1)[-1]:
-            host, port_s = endpoint[len("tcp://") :].rsplit(":", 1)
+        if endpoint.startswith("tcp://"):
+            host_port = endpoint[len("tcp://") :]
+            if ":" not in host_port:
+                return "tcp://127.0.0.1:5556"
+            host, port_s = host_port.rsplit(":", 1)
             port = int(port_s)
             return f"tcp://{host}:{port+1}"
     except Exception:

--- a/hotweights/core/schemas.py
+++ b/hotweights/core/schemas.py
@@ -48,6 +48,7 @@ class PlanItem(TypedDict, total=False):
     shape: Optional[List[int]]
     key: str
     offset: int
+    tp_group: int | str
 
 
 class PlanBucket(TypedDict, total=False):

--- a/hotweights/transport/gds_storage.py
+++ b/hotweights/transport/gds_storage.py
@@ -30,17 +30,18 @@ class GDSDirectTransfer:
         self.device_id = device_id
         self._initialized = False
         self._gds_context = None
+        self._gds_available = GDS_AVAILABLE
         
-        if GDS_AVAILABLE:
+        if self._gds_available:
             try:
                 self._initialize_gds()
             except Exception as e:
                 logger.warning(f"Failed to initialize GDS: {e}")
-                GDS_AVAILABLE = False
+                self._gds_available = False
     
     def _initialize_gds(self):
         """Initialize GPUDirect Storage context."""
-        if not GDS_AVAILABLE:
+        if not self._gds_available:
             return
             
         # Set CUDA device
@@ -125,7 +126,7 @@ class GDSDirectTransfer:
     @property
     def is_available(self) -> bool:
         """Check if GPUDirect Storage is available and initialized."""
-        return self._initialized and GDS_AVAILABLE
+        return self._initialized and self._gds_available
 
 
 class GDSFallbackTransfer:
@@ -169,7 +170,7 @@ class GDSFallbackTransfer:
         stream.synchronize()
 
 
-def create_gds_transfer(device_id: int = 0) -> GDSDirectTransfer:
+def create_gds_transfer(device_id: int = 0) -> GDSDirectTransfer | GDSFallbackTransfer:
     """Factory function to create appropriate transfer mechanism."""
     if GDS_AVAILABLE:
         try:

--- a/hotweights/transport/topology_scheduler.py
+++ b/hotweights/transport/topology_scheduler.py
@@ -300,7 +300,7 @@ class TopologyAwareScheduler:
     def compute_transfer_schedule(self, bucket_id: int, src_rank: int, 
                                  dst_ranks: List[int], size_bytes: int) -> TransferSchedule:
         """Compute optimal transfer schedule for a bucket."""
-        with Timer() as timer:
+        with Timer("topology_schedule") as timer:
             # Get source GPU topology
             src_gpu = self.topology.gpus.get(src_rank)
             if not src_gpu:

--- a/hotweights/transport/ucx_stream.py
+++ b/hotweights/transport/ucx_stream.py
@@ -253,14 +253,11 @@ class UCXReplicator(Transport):
                 ep = await ucp.create_endpoint(self.master_addr, self.master_port)
                 for item in bucket_iter:
                     if len(item) == 3:
-                        bucket_id, buf, consumers = item  # type: ignore[misc]
-                        if self.rank not in consumers:
-                            # Skip receive for non-consumer ranks
-                            continue
+                        bucket_id, buf, _consumers = item  # type: ignore[misc]
                     else:
                         bucket_id, buf = item  # type: ignore[misc]
                     await self._recv_into(ep, buf)
-                    on_complete(bucket_id, buf)
+                    on_complete(int(bucket_id), buf)
                 try:
                     await ep.close()
                 except Exception:

--- a/tests/test_cuda_ipc_window.py
+++ b/tests/test_cuda_ipc_window.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+
+from hotweights.transport.cuda_ipc import CudaIPCTransport
+
+
+class _Metrics:
+    def set_inflight(self, buckets: int, bytes_: int) -> None:
+        _ = (buckets, bytes_)
+
+    def set_congestion_risk(self, risk: float) -> None:
+        _ = risk
+
+    def set_recommended_window(self, window: int) -> None:
+        _ = window
+
+    def set_window(self, window: int) -> None:
+        _ = window
+
+    def set_path_utilization(self, path_key: str, value: float) -> None:
+        _ = (path_key, value)
+
+
+class _Log:
+    def debug(self, msg: str) -> None:
+        _ = msg
+
+
+def test_run_replication_dynamic_window_does_not_raise_unboundlocal() -> None:
+    class Dummy:
+        pass
+
+    d = Dummy()
+    d._sched = None
+    d.world_size = 2
+    d._max_inflight_cap = 4
+    d._max_inflight = 1
+    d._max_inflight_bytes = 0
+    d._adapt = False
+    d.metrics = _Metrics()
+    d._log = _Log()
+
+    async def _replicate_one_bucket(bucket, plan):  # noqa: ANN001, ANN202
+        _ = (bucket, plan)
+
+    d._replicate_one_bucket = _replicate_one_bucket
+    run = CudaIPCTransport._run_replication.__get__(d, CudaIPCTransport)
+    asyncio.run(
+        run(
+            {
+                "buckets": [
+                    {"bucket_id": 0, "size": 1, "items": []},
+                    {"bucket_id": 1, "size": 1, "items": []},
+                ]
+            }
+        )
+    )

--- a/tests/test_endpoint_derivation.py
+++ b/tests/test_endpoint_derivation.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from hotweights.cli import _derive_pub_endpoint as cli_pub_endpoint
+from hotweights.coordinator.zmq_server import _derive_pub_endpoint as server_pub_endpoint
+from hotweights.worker.agent import _derive_pub_endpoint as worker_pub_endpoint
+
+
+def test_derive_pub_endpoint_from_tcp_rep_endpoint() -> None:
+    rep = "tcp://10.1.2.3:7000"
+    expected = "tcp://10.1.2.3:7001"
+    assert cli_pub_endpoint(rep) == expected
+    assert worker_pub_endpoint(rep) == expected
+    assert server_pub_endpoint(rep) == expected

--- a/tests/test_kv_and_gds.py
+++ b/tests/test_kv_and_gds.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from hotweights.transport.gds_storage import GDSDirectTransfer
+
+
+def test_gds_direct_transfer_init_does_not_raise_unboundlocal() -> None:
+    tr = GDSDirectTransfer()
+    assert isinstance(tr.is_available, bool)
+
+
+def test_kv_migration_handles_models_without_device_attr() -> None:
+    torch = pytest.importorskip("torch")
+    from hotweights.adapters.kv_cache_migration import migrate_kv_cache
+
+    model = torch.nn.Linear(2, 2)
+    kv_old = [(torch.zeros(2, 1, 1), torch.zeros(2, 1, 1))]
+    kv_new, report = migrate_kv_cache(kv_old, model, {"buckets": []})
+    assert len(kv_new) == 1
+    assert report["migrated_layers"] == 1

--- a/tests/test_verify_plan_core.py
+++ b/tests/test_verify_plan_core.py
@@ -18,3 +18,23 @@ def test_verify_plan_basic_missing_and_range():
     assert report["buckets_with_out_of_range"] == 1
     assert len(report["problems"]) >= 2
 
+
+def test_verify_plan_enforce_tp_superset_uses_item_tp_group() -> None:
+    plan = {
+        "buckets": [
+            {
+                "bucket_id": 0,
+                "items": [{"key": "a:0", "tp_group": "0"}],
+                "size": 0,
+                "consumer_ranks": [0],
+            }
+        ]
+    }
+    report = verify_plan(
+        plan,
+        require_consumers=True,
+        world_size=2,
+        tp_groups={"0": [0, 1]},
+        enforce_tp_superset=True,
+    )
+    assert any(p.get("error") == "consumer_ranks not superset of TP group" for p in report["problems"])

--- a/tests/test_vllm_auto.py
+++ b/tests/test_vllm_auto.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import types
 
+import hotweights.adapters.vllm_bind as vllm_bind
 from hotweights.adapters.vllm_auto import install_autobind
 
 
@@ -42,3 +43,18 @@ def test_install_autobind_patches_fake_engines(monkeypatch):
     assert getattr(a, "initialized", False) is True
     assert getattr(l, "initialized", False) is True
 
+
+def test_bind_to_vllm_accepts_compat_kwargs(monkeypatch):
+    class Dummy:
+        model = object()
+
+    monkeypatch.setattr(vllm_bind.HotweightsVLLMBinding, "start", lambda self: None)
+    binding = vllm_bind.bind_to_vllm(
+        Dummy(),
+        None,
+        endpoint="tcp://127.0.0.1:5555",
+        use_mpi=True,
+        pinned=False,
+        verify=True,
+    )
+    assert isinstance(binding, vllm_bind.HotweightsVLLMBinding)

--- a/tests/test_vllm_pause.py
+++ b/tests/test_vllm_pause.py
@@ -17,3 +17,14 @@ def test_pause_resume_best_effort():
     resume_requests(eng)
     assert calls == ["pause", "resume"]
 
+
+def test_pause_accepts_drain_flag() -> None:
+    eng = types.SimpleNamespace()
+    calls: list[str] = []
+    eng.pause_requests = lambda: calls.append("pause")  # type: ignore[attr-defined]
+    eng.resume_requests = lambda: calls.append("resume")  # type: ignore[attr-defined]
+    eng.num_active_requests = 5  # type: ignore[attr-defined]
+
+    pause_requests(eng, timeout_s=0.01, drain=False)
+    resume_requests(eng)
+    assert calls == ["pause", "resume"]

--- a/tests/test_worker_agent.py
+++ b/tests/test_worker_agent.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from hotweights.worker.agent import WorkerConfig, run_worker
+
+
+class _FakeTransport:
+    def __init__(self) -> None:
+        self.replicated = False
+
+    def replicate(self, plan: dict) -> None:
+        _ = plan
+        self.replicated = True
+
+
+class _FakeClientNoSub:
+    def __init__(self) -> None:
+        self._status_idx = 0
+        self.calls: list[str] = []
+
+    def call(self, method: str, **kwargs):  # noqa: ANN003, ANN201
+        _ = kwargs
+        self.calls.append(method)
+        if method == "get_plan":
+            return {"plan": {"version": "v1", "buckets": []}}
+        if method == "status":
+            states = [
+                {"state": "precommit", "version": "v1"},
+                {"state": "committed", "version": "v1"},
+            ]
+            out = states[min(self._status_idx, len(states) - 1)]
+            self._status_idx += 1
+            return out
+        return {"ok": True}
+
+
+class _FakeClientSub:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def call(self, method: str, **kwargs):  # noqa: ANN003, ANN201
+        _ = kwargs
+        self.calls.append(method)
+        if method == "get_plan":
+            return {"plan": {"version": "v1", "buckets": []}}
+        if method == "status":
+            return {"state": "precommit", "version": "v1"}
+        return {"ok": True}
+
+
+class _FakeSubscriber:
+    def __init__(self, events: list[tuple[str, dict]]) -> None:
+        self._events = events
+        self._idx = 0
+
+    def recv(self):  # noqa: ANN201
+        out = self._events[min(self._idx, len(self._events) - 1)]
+        self._idx += 1
+        return out
+
+
+def _install_worker_dummies(monkeypatch, client, subscriber=None) -> _FakeTransport:  # noqa: ANN001
+    import hotweights.worker.agent as wa
+
+    tr = _FakeTransport()
+    monkeypatch.setattr(wa, "Client", lambda endpoint: client)
+    if subscriber is not None:
+        monkeypatch.setattr(wa, "Subscriber", lambda endpoint: subscriber)
+    monkeypatch.setattr(wa, "CudaIPCMetrics", lambda rank: object())
+    monkeypatch.setattr(wa, "CudaIPCAgent", lambda device, metrics: object())
+    monkeypatch.setattr(
+        wa, "CudaIPCTransport", lambda agent, metrics, coord_endpoint: tr
+    )
+    monkeypatch.setattr(wa, "start_http_server", lambda port: None)
+    monkeypatch.setattr(wa.time, "sleep", lambda _s: None)
+    return tr
+
+
+def test_worker_runs_without_subscriber(monkeypatch) -> None:
+    client = _FakeClientNoSub()
+    tr = _install_worker_dummies(monkeypatch, client)
+    cfg = WorkerConfig(endpoint="tcp://127.0.0.1:5555", device="cuda", use_sub=False)
+    rc = run_worker(cfg)
+    assert rc == 0
+    assert tr.replicated is True
+    assert "status" in client.calls
+
+
+def test_worker_validates_event_token(monkeypatch) -> None:
+    client = _FakeClientSub()
+    sub = _FakeSubscriber(
+        [
+            ("begin", {"tok": "bad"}),
+            ("begin", {"tok": "secret"}),
+            ("commit", {"version": "v1", "accepted": True, "tok": "bad"}),
+            ("commit", {"version": "v1", "accepted": True, "tok": "secret"}),
+        ]
+    )
+    tr = _install_worker_dummies(monkeypatch, client, subscriber=sub)
+    cfg = WorkerConfig(
+        endpoint="tcp://127.0.0.1:5555",
+        device="cuda",
+        use_sub=True,
+        event_token="secret",
+    )
+    rc = run_worker(cfg)
+    assert rc == 0
+    assert tr.replicated is True


### PR DESCRIPTION
## Summary
- fix CUDA-IPC runtime blockers by removing hard dependency on `torch.cuda.ipc` and hardening inflight window control
- fix vLLM binder API mismatches (`drain` support and compatibility kwargs)
- fix worker coordinator flow (`--no-sub` path + event-token validation) and PUB endpoint derivation logic
- enforce TP superset validation by carrying `tp_group` metadata into plans
- fix GDS initialization scoping bug and topology scheduler timer call
- prevent UCX consumer-scoped deadlocks by always receiving stream payloads and gating scatter locally

## Validation
- `pytest -q` (29 passed)
- targeted runtime repros for vLLM bind kwargs, pause drain, endpoint derivation, GDS init, and KV migration

## Notes
- The existing external Bodo `atexit` assertion still appears after pytest in this environment (unchanged in this PR).
